### PR TITLE
[Fix] Stop Boss Skill Dead State

### DIFF
--- a/Source/ST/Private/Enemy/STEnemyBoss.cpp
+++ b/Source/ST/Private/Enemy/STEnemyBoss.cpp
@@ -205,6 +205,12 @@ void ASTEnemyBoss::Die()
             AIController->BrainComponent->StopLogic(TEXT("Dead"));
         }
     }
+	
+	if (SkillComponent)
+	{
+		SkillComponent->ForceStopAllSkills();
+		SkillComponent->CleanupActiveParticles();
+	}
 
     if (GetMesh()->GetAnimInstance())
     {


### PR DESCRIPTION
보스가 죽을 때 모든 스킬 강제 취소, 파티클 제거

# 변경 유형

- [] 기능 추가
- [x] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 기타(아래에 작성)

# 수정 내용
보스가 죽을 때 모든 스킬 강제 취소, 파티클 제거
-

# 스크린샷(선택)
