### PR TITLE
Feature/UI

### DIFF
--- a/Content/UI/UI_BP/BP_GameClearUI.uasset
+++ b/Content/UI/UI_BP/BP_GameClearUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2fcee71f7961649d68a451fe211297605304941edb54c1984bf4a3dbde8c8fca
-size 49632
+oid sha256:1dce401eccb69494a1517361287db1e8309bada5d5e154c5c6d445008927e3f6
+size 53248

--- a/Content/UI/UI_BP/BP_PauseMenuUI.uasset
+++ b/Content/UI/UI_BP/BP_PauseMenuUI.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8cb31ee68c32ae60de01ddf7b0e94b087034d22a8b8d1b549d1e4a966c575109
-size 46176
+oid sha256:bd342ce542c1c58a37474f815a294a51fce954cc51d610935176246e1dd78da6
+size 46029

--- a/Content/UI/UI_Image/EBImage.uasset
+++ b/Content/UI/UI_Image/EBImage.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e641ed7e76b1cdee72072b8734fec8018faded436bc0e372222146a2fd32c626
+size 2157331

--- a/Source/ST/Private/UI/STGameClearWidget.cpp
+++ b/Source/ST/Private/UI/STGameClearWidget.cpp
@@ -18,6 +18,10 @@ void USTGameClearWidget::NativeConstruct()
 	{
 		Btn_ReturnToMain->OnClicked.AddDynamic(this, &USTGameClearWidget::HandleReturnToMainClicked);
 	}
+	if (Btn_Ending)
+	{
+		Btn_Ending->OnClicked.AddDynamic(this, &USTGameClearWidget::HandlePlayEndingClicked);
+	}
 }
 
 void USTGameClearWidget::SetResultInfo(int32 Score, int32 HighScore)
@@ -37,4 +41,9 @@ void USTGameClearWidget::HandleRetryClicked()
 void USTGameClearWidget::HandleReturnToMainClicked()
 {
 	OnReturnToMainRequested.Broadcast();
+}
+
+void USTGameClearWidget::HandlePlayEndingClicked()
+{
+	OnPlayEndingRequested.Broadcast();
 }

--- a/Source/ST/Private/UI/STPauseMenuWidget.cpp
+++ b/Source/ST/Private/UI/STPauseMenuWidget.cpp
@@ -7,6 +7,8 @@ void USTPauseMenuWidget::NativeConstruct()
 {
 	Super::NativeConstruct();
 
+	SetIsFocusable(true);
+
 	if (Btn_ResumeGame)
 		Btn_ResumeGame->OnClicked.AddDynamic(this, &USTPauseMenuWidget::OnResumeClicked);
 
@@ -36,4 +38,14 @@ void USTPauseMenuWidget::OnQuitClicked()
 void USTPauseMenuWidget::OnReturnToMainClicked()
 {
 	OnReturnToMainRequested.Broadcast();
+}
+
+FReply USTPauseMenuWidget::NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent)
+{
+	if (InKeyEvent.GetKey() == EKeys::Escape)
+	{
+		OnResumeClicked();
+		return FReply::Handled();
+	}
+	return Super::NativeOnKeyDown(InGeometry, InKeyEvent);
 }

--- a/Source/ST/Private/UI/STStagePlayerController.cpp
+++ b/Source/ST/Private/UI/STStagePlayerController.cpp
@@ -887,6 +887,7 @@ void ASTStagePlayerController::ShowGameClearResult()
 			
 			GameClearWidget->OnRetryRequested.AddDynamic(this, &ASTStagePlayerController::HandleGameClearRetry);
 			GameClearWidget->OnReturnToMainRequested.AddDynamic(this, &ASTStagePlayerController::HandleGameClearReturnToMain);
+			GameClearWidget->OnPlayEndingRequested.AddDynamic(this, &ASTStagePlayerController::HandlePlayEndingRequested);
 		}
 	}
 
@@ -1092,6 +1093,23 @@ void ASTStagePlayerController::HandleGameClearReturnToMain()
 	{
 		GI->GoToMainMenu();
 	}*/
+}
+
+void ASTStagePlayerController::HandlePlayEndingRequested()
+{
+	// 임시 로그 출력
+	UE_LOG(LogSystem, Log, TEXT("엔딩 영상을 출력합니다"));
+
+	// 화면에 임시 디버그 메시지도 표시
+	if (GEngine)
+	{
+		GEngine->AddOnScreenDebugMessage(
+			-1,           
+			2.0f,          
+			FColor::Cyan,  
+			TEXT("엔딩 영상을 출력합니다")
+		);
+	}
 }
 
 // JM: 레벨이동 통합관리

--- a/Source/ST/Private/UI/STStagePlayerController.cpp
+++ b/Source/ST/Private/UI/STStagePlayerController.cpp
@@ -195,7 +195,8 @@ void ASTStagePlayerController::SetupInputComponent()
 
 	// 테스트용 키 (P)
 	InputComponent->BindKey(EKeys::P, IE_Pressed, this, &ASTStagePlayerController::TogglePauseMenu);
-
+	// ESC도 토글
+	InputComponent->BindKey(EKeys::Escape, IE_Pressed, this, &ASTStagePlayerController::TogglePauseMenu);
 	// Tab 키 입력 바인딩
 	InputComponent->BindKey(EKeys::Tab, IE_Pressed, this, &ASTStagePlayerController::ShowScoreboard);
 	InputComponent->BindKey(EKeys::Tab, IE_Released, this, &ASTStagePlayerController::HideScoreboard);
@@ -608,9 +609,14 @@ void ASTStagePlayerController::HideBossBar()
 
 void ASTStagePlayerController::TogglePauseMenu()
 {
+	if (GameOverWidget || GameClearWidget)
+	{
+		return;
+	}
+
 	if (IsPaused())
 	{
-		// 게임 재개
+		// === 게임 재개 ===
 		SetPause(false);
 
 		if (PauseMenuWidget)
@@ -623,7 +629,7 @@ void ASTStagePlayerController::TogglePauseMenu()
 	}
 	else
 	{
-		// 게임 일시정지
+		// === 게임 일시정지 ===
 		SetPause(true);
 
 		if (!PauseMenuWidget && PauseMenuWidgetClass)
@@ -640,9 +646,13 @@ void ASTStagePlayerController::TogglePauseMenu()
 		if (PauseMenuWidget)
 		{
 			PauseMenuWidget->SetVisibility(ESlateVisibility::Visible);
-		}
 
-		SetInputMode(FInputModeUIOnly());
+			// 입력 모드로 ESC가 컨트롤러에 도달하도록 설정
+			FInputModeGameAndUI InputMode;
+			InputMode.SetWidgetToFocus(PauseMenuWidget->TakeWidget());
+			InputMode.SetLockMouseToViewportBehavior(EMouseLockMode::DoNotLock);
+			SetInputMode(InputMode);
+		}
 		bShowMouseCursor = true;
 	}
 }

--- a/Source/ST/Public/UI/STGameClearWidget.h
+++ b/Source/ST/Public/UI/STGameClearWidget.h
@@ -20,12 +20,16 @@ public:
 
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnRetryRequested);
 	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnReturnToMainRequested);
+	DECLARE_DYNAMIC_MULTICAST_DELEGATE(FOnPlayEndingRequested);
 
 	UPROPERTY(BlueprintAssignable, Category="Event")
 	FOnRetryRequested OnRetryRequested;
 
 	UPROPERTY(BlueprintAssignable, Category="Event")
 	FOnReturnToMainRequested OnReturnToMainRequested;
+
+	UPROPERTY(BlueprintAssignable, Category="Event")
+	FOnPlayEndingRequested OnPlayEndingRequested;
 	
 protected:
 	virtual void NativeConstruct() override;
@@ -35,8 +39,10 @@ protected:
 
 	UPROPERTY(meta = (BindWidget)) UButton* Btn_Retry;
 	UPROPERTY(meta = (BindWidget)) UButton* Btn_ReturnToMain;
+	UPROPERTY(meta = (BindWidget)) UButton* Btn_Ending;
 	
 private:
 	UFUNCTION() void HandleRetryClicked();
 	UFUNCTION() void HandleReturnToMainClicked();
+	UFUNCTION() void HandlePlayEndingClicked();
 };

--- a/Source/ST/Public/UI/STPauseMenuWidget.h
+++ b/Source/ST/Public/UI/STPauseMenuWidget.h
@@ -31,4 +31,6 @@ protected:
 	UFUNCTION() void OnReturnToMainClicked();
 	UFUNCTION() void OnResumeClicked();
 	UFUNCTION() void OnQuitClicked();
+
+	virtual FReply NativeOnKeyDown(const FGeometry& InGeometry, const FKeyEvent& InKeyEvent) override;
 };

--- a/Source/ST/Public/UI/STStagePlayerController.h
+++ b/Source/ST/Public/UI/STStagePlayerController.h
@@ -74,6 +74,7 @@ public:
 	UFUNCTION()	void HandleGameOverReturnToMain();
 	UFUNCTION()	void HandleGameClearRetry();
 	UFUNCTION()	void HandleGameClearReturnToMain();
+	UFUNCTION()	void HandlePlayEndingRequested();
 	
 
 	// Game Over / Clear UI

--- a/Source/ST/Public/UI/STStagePlayerController.h
+++ b/Source/ST/Public/UI/STStagePlayerController.h
@@ -184,6 +184,11 @@ private:
 	void ScheduleGameOver(float DelaySeconds);
 	FTimerHandle GameOverTimerHandle;
 	float GameOverDelay = 1.5f;
+
+	UFUNCTION()
+	void ScheduleGameClear(float DelaySeconds);
+	FTimerHandle GameClearTimerHandle;
+	float GameClearDelay = 1.5f;
 	
 	FDelegateHandle ActorSpawnedHandle;
 	
@@ -195,7 +200,6 @@ private:
 	
 	bool bPrevZoomState = false;
 	bool bGameOverShown = false;
-	bool bGameClearShown = false;
 
 	// 현재 장착 무기 이름 & 샷건 여부
 	UPROPERTY()


### PR DESCRIPTION
# 변경 유형

- [x] 기능 추가
- [ ] 버그 수정
- [ ] 리팩토링
- [ ] 테스트
- [ ] 기타(아래에 작성)

# 수정 내용

[ADD] 엔딩시 페이드 아웃/인 적용
 - 엔딩화면 진입 시 페이드 아웃/인 적용
[Update] 메뉴 버튼 순서 변경
 - resume, main, quit 순서로 변경 
[ADD] 일시정지 메뉴 esc추가
 - 일시정지 메뉴에서 esc 누를시 메뉴 닫힘
[ADD] 게임클리어 메뉴 Ending 버튼 추가
 - 누르면 임시 로그 메세지 출력

# 스크린샷(선택)
